### PR TITLE
Fix anti-bot analysis when Etherscan fails

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,6 +61,9 @@ erc20_abi = [
 ]
 
 if token_address:
+    # Ensure variables are defined even if API requests fail
+    is_verified = False
+    contract_info = {}
     try:
         contract = web3.eth.contract(address=web3.to_checksum_address(token_address), abi=erc20_abi)
         name = contract.functions.name().call()


### PR DESCRIPTION
## Summary
- initialize `is_verified` and `contract_info` before API requests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884c2ae113483309a7de6329fe19e4a